### PR TITLE
Add larger board modes and improve visual scale/confetti

### DIFF
--- a/gameLogic.js
+++ b/gameLogic.js
@@ -1,18 +1,29 @@
-export const WIN_LINES = [
-  [0, 1, 2],
-  [3, 4, 5],
-  [6, 7, 8],
-  [0, 3, 6],
-  [1, 4, 7],
-  [2, 5, 8],
-  [0, 4, 8],
-  [2, 4, 6],
-];
+export function buildWinLines(size = 3) {
+  const lines = [];
 
-export function evaluateBoard(board) {
-  for (const [a, b, c] of WIN_LINES) {
-    if (board[a] && board[a] === board[b] && board[b] === board[c]) {
-      return { winner: board[a], line: [a, b, c], isDraw: false };
+  for (let row = 0; row < size; row += 1) {
+    lines.push(Array.from({ length: size }, (_, col) => row * size + col));
+  }
+
+  for (let col = 0; col < size; col += 1) {
+    lines.push(Array.from({ length: size }, (_, row) => row * size + col));
+  }
+
+  lines.push(Array.from({ length: size }, (_, i) => i * size + i));
+  lines.push(Array.from({ length: size }, (_, i) => i * size + (size - 1 - i)));
+
+  return lines;
+}
+
+export function evaluateBoard(board, size = 3) {
+  const winLines = buildWinLines(size);
+
+  for (const line of winLines) {
+    const [first, ...rest] = line;
+    const firstValue = board[first];
+    if (!firstValue) continue;
+    if (rest.every((idx) => board[idx] === firstValue)) {
+      return { winner: firstValue, line, isDraw: false };
     }
   }
 
@@ -28,7 +39,7 @@ export function getAvailableMoves(board) {
 }
 
 function minimax(board, depth, isMaximizing, aiPlayer, humanPlayer) {
-  const result = evaluateBoard(board);
+  const result = evaluateBoard(board, 3);
   if (result.winner === aiPlayer) return 10 - depth;
   if (result.winner === humanPlayer) return depth - 10;
   if (result.isDraw) return 0;
@@ -56,7 +67,12 @@ function minimax(board, depth, isMaximizing, aiPlayer, humanPlayer) {
   return bestScore;
 }
 
-export function getBestMove(board, aiPlayer = 'O', humanPlayer = 'X') {
+export function getBestMove(board, aiPlayer = 'O', humanPlayer = 'X', size = 3) {
+  if (size !== 3) {
+    const moves = getAvailableMoves(board);
+    return moves.length ? moves[Math.floor(Math.random() * moves.length)] : -1;
+  }
+
   let bestScore = -Infinity;
   let move = -1;
 

--- a/gameLogic.test.js
+++ b/gameLogic.test.js
@@ -1,18 +1,35 @@
 import { describe, expect, it } from 'vitest';
-import { evaluateBoard, getAvailableMoves, getBestMove } from './gameLogic.js';
+import { buildWinLines, evaluateBoard, getAvailableMoves, getBestMove } from './gameLogic.js';
+
+describe('buildWinLines', () => {
+  it('builds expected win-line count for 5x5', () => {
+    expect(buildWinLines(5)).toHaveLength(12);
+  });
+});
 
 describe('evaluateBoard', () => {
-  it('detects a winner and winning line', () => {
-    const result = evaluateBoard(['X', 'X', 'X', '', '', '', '', '', '']);
+  it('detects a winner and winning line on 3x3', () => {
+    const result = evaluateBoard(['X', 'X', 'X', '', '', '', '', '', ''], 3);
     expect(result.winner).toBe('X');
     expect(result.line).toEqual([0, 1, 2]);
     expect(result.isDraw).toBe(false);
   });
 
   it('detects draw', () => {
-    const result = evaluateBoard(['X', 'O', 'X', 'X', 'O', 'O', 'O', 'X', 'X']);
+    const result = evaluateBoard(['X', 'O', 'X', 'X', 'O', 'O', 'O', 'X', 'X'], 3);
     expect(result.winner).toBe(null);
     expect(result.isDraw).toBe(true);
+  });
+
+  it('detects winner on 4x4 row', () => {
+    const result = evaluateBoard([
+      'O', 'O', 'O', 'O',
+      '', '', '', '',
+      '', '', '', '',
+      '', '', '', '',
+    ], 4);
+    expect(result.winner).toBe('O');
+    expect(result.line).toEqual([0, 1, 2, 3]);
   });
 });
 
@@ -25,11 +42,21 @@ describe('getAvailableMoves', () => {
 describe('getBestMove', () => {
   it('takes a winning move', () => {
     const board = ['O', 'O', '', 'X', 'X', '', '', '', ''];
-    expect(getBestMove(board, 'O', 'X')).toBe(2);
+    expect(getBestMove(board, 'O', 'X', 3)).toBe(2);
   });
 
   it('blocks opponent winning move', () => {
     const board = ['X', 'X', '', '', 'O', '', '', '', ''];
-    expect(getBestMove(board, 'O', 'X')).toBe(2);
+    expect(getBestMove(board, 'O', 'X', 3)).toBe(2);
+  });
+
+  it('returns a legal move for larger boards', () => {
+    const board = Array(16).fill('');
+    board[0] = 'X';
+    board[5] = 'O';
+    const move = getBestMove(board, 'O', 'X', 4);
+    expect(move).toBeGreaterThanOrEqual(0);
+    expect(move).toBeLessThan(16);
+    expect(board[move]).toBe('');
   });
 });

--- a/index.html
+++ b/index.html
@@ -19,6 +19,14 @@
         </select>
       </label>
       <label>
+        Board Size
+        <select id="sizeSelect" aria-label="Board size selector">
+          <option value="3">3x3</option>
+          <option value="4">4x4</option>
+          <option value="5">5x5</option>
+        </select>
+      </label>
+      <label>
         Theme
         <select id="themeSelect" aria-label="Theme selector">
           <option value="midnight">Midnight</option>
@@ -38,17 +46,7 @@
       <div><span>Draws</span><strong id="scoreDraw">0</strong></div>
     </section>
 
-    <section class="board" id="board" aria-label="Tic-Tac-Toe board">
-      <button class="cell" data-i="0" aria-label="Cell 1"></button>
-      <button class="cell" data-i="1" aria-label="Cell 2"></button>
-      <button class="cell" data-i="2" aria-label="Cell 3"></button>
-      <button class="cell" data-i="3" aria-label="Cell 4"></button>
-      <button class="cell" data-i="4" aria-label="Cell 5"></button>
-      <button class="cell" data-i="5" aria-label="Cell 6"></button>
-      <button class="cell" data-i="6" aria-label="Cell 7"></button>
-      <button class="cell" data-i="7" aria-label="Cell 8"></button>
-      <button class="cell" data-i="8" aria-label="Cell 9"></button>
-    </section>
+    <section class="board" id="board" aria-label="Tic-Tac-Toe board"></section>
 
     <div class="controls">
       <button id="reset">Next Round</button>

--- a/styles.css
+++ b/styles.css
@@ -90,7 +90,7 @@ h1 {
 
 .panel {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 10px;
   margin-bottom: 10px;
 }
@@ -142,15 +142,17 @@ select {
 }
 
 .board {
+  --size: 3;
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(var(--size), 1fr);
   gap: 10px;
 }
 
 .cell {
   aspect-ratio: 1;
-  font-size: clamp(1.8rem, 8vw, 2.5rem);
-  font-weight: 700;
+  font-size: clamp(1.4rem, calc(18vw / var(--size)), 3rem);
+  line-height: 1;
+  font-weight: 800;
   border: none;
   border-radius: 14px;
   background: var(--surface-2);


### PR DESCRIPTION
## Summary\n- add selectable 3x3 / 4x4 / 5x5 board modes\n- make win detection dynamic by board size\n- improve X/O mark scaling so symbols better fill each cell across sizes\n- increase confetti particle count and duration for stronger celebration\n- add unit tests for dynamic win-lines and larger-board AI move behavior\n\n## Testing\n- npm test\n\nFixes #5\nFixes #6\nFixes #7